### PR TITLE
Hide thumbnail when page has Gutenberg layout

### DIFF
--- a/packages/app/pages/_slug.vue
+++ b/packages/app/pages/_slug.vue
@@ -70,7 +70,7 @@
         v-html="hasChildren ? activeChild.title.rendered : page.title.rendered"
       />
       <figure
-        v-if="page._embedded['wp:featuredmedia']"
+        v-if="page._embedded['wp:featuredmedia'] && !isGutenberg"
         class="thumbnail"
       >
         <ZImage


### PR DESCRIPTION
Dla og:title należy ustawić obrazek wyróżniający. Nie zostanie on wyświetlony na stronie.  