### PR TITLE
Update blocks dependencies

### DIFF
--- a/packages/theme/.gitignore
+++ b/packages/theme/.gitignore
@@ -1,0 +1,2 @@
+includes/acf
+!includes/acf/README.md

--- a/packages/theme/blocks/button/package.json
+++ b/packages/theme/blocks/button/package.json
@@ -14,6 +14,7 @@
 		"packages-update": "wp-scripts packages-update"
 	},
 	"dependencies": {
+		"@babel/runtime": "^7.15.4",
 		"@wordpress/block-editor": "^5.2.6",
 		"@wordpress/blocks": "^7.0.3",
 		"@wordpress/i18n": "^3.18.0"

--- a/packages/theme/blocks/card/package.json
+++ b/packages/theme/blocks/card/package.json
@@ -14,6 +14,7 @@
 		"packages-update": "wp-scripts packages-update"
 	},
 	"dependencies": {
+		"@babel/runtime": "^7.15.4",
 		"@wordpress/block-editor": "^5.2.6",
 		"@wordpress/blocks": "^7.0.3",
 		"@wordpress/i18n": "^3.18.0"

--- a/packages/theme/blocks/divider/package.json
+++ b/packages/theme/blocks/divider/package.json
@@ -14,6 +14,7 @@
 		"packages-update": "wp-scripts packages-update"
 	},
 	"dependencies": {
+		"@babel/runtime": "^7.15.4",
 		"@wordpress/block-editor": "^5.2.6",
 		"@wordpress/blocks": "^7.0.3",
 		"@wordpress/i18n": "^3.18.0"

--- a/packages/theme/blocks/icon/package.json
+++ b/packages/theme/blocks/icon/package.json
@@ -14,6 +14,7 @@
 		"packages-update": "wp-scripts packages-update"
 	},
 	"dependencies": {
+		"@babel/runtime": "^7.15.4",
 		"@fortawesome/fontawesome-free": "^5.15.2",
 		"@wordpress/block-editor": "^5.2.6",
 		"@wordpress/blocks": "^7.0.3",

--- a/packages/theme/blocks/section/package.json
+++ b/packages/theme/blocks/section/package.json
@@ -14,6 +14,7 @@
 		"packages-update": "wp-scripts packages-update"
 	},
 	"dependencies": {
+		"@babel/runtime": "^7.15.4",
 		"@wordpress/block-editor": "^5.2.6",
 		"@wordpress/blocks": "^7.0.3",
 		"@wordpress/data": "^4.26.6",


### PR DESCRIPTION
W niektórych z bloków brakowało w `package.json` jednej z zależności: `@babel.runtime`, co, przy próbie buildu, powodowało błąd:
```
yarn run v1.22.5
$ wp-scripts build
Hash: 338da7fd450961e5f89a
Version: webpack 4.46.0
Time: 6928ms
Built at: 04.11.2021 23:44:14
 2 assets
Entrypoint index = index.css index.js
[0] external ["wp","element"] 42 bytes {0} [built]
[1] external ["wp","components"] 42 bytes {0} [built]
[2] external ["wp","blockEditor"] 42 bytes {0} [built]
[3] external ["wp","blocks"] 42 bytes {0} [built]
[4] ./src/editor.scss 39 bytes {0} [built]
[5] ./src/index.js + 2 modules 9.47 KiB {0} [built]
    | ./src/index.js 1.98 KiB [built]
    | ./src/edit.js 4.76 KiB [built]
    | ./src/save.js 2.71 KiB [built]
    + 1 hidden module

ERROR in ./src/edit.js
Module not found: Error: Can't resolve '@babel/runtime/helpers/defineProperty' in 'N:\Programming\php\zhp-pl\packages\theme\blocks\divider\src'
 @ ./src/edit.js 2:0-68 7:201-216 41:71-86
 @ ./src/index.js

ERROR in ./src/save.js
Module not found: Error: Can't resolve '@babel/runtime/helpers/defineProperty' in 'N:\Programming\php\zhp-pl\packages\theme\blocks\divider\src'
 @ ./src/save.js 1:0-68 6:201-216 47:71-86
 @ ./src/index.js

ERROR in ./src/edit.js
Module not found: Error: Can't resolve '@babel/runtime/helpers/extends' in 'N:\Programming\php\zhp-pl\packages\theme\blocks\divider\src'
 @ ./src/edit.js 1:0-54 128:31-39
 @ ./src/index.js
error Command failed with exit code 2.
```