### PR TITLE
Deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+**/node_modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+name: Build theme for WP sites
+
+on: 
+  push:
+    branches:
+      - theme
+  workflow_dispatch:
+
+jobs:
+  
+  build:
+    name: Build 
+    runs-on: ubuntu-latest  
+    env:
+      UPDATE_DETAILS_URL: 'https://github.com/${{ github.repository }}/releases/latest/download/details.json'
+    steps:
+      - name: Set current version
+        run: echo "VERSION=$(date '+%Y.%m.%d.%H.%M.%S')" >> $GITHUB_ENV
+      - uses: actions/checkout@v3
+      - name: Build the Docker image
+        run: |
+          docker build \
+            --file Dockerfile_build \
+            --tag zhp-pl:latest \
+            --build-arg THEME_VERSION="${VERSION}" \
+            --build-arg UPDATE_DETAILS_URL=${{ env.UPDATE_DETAILS_URL }} \
+            .
+      - name: Extract theme
+        run: docker run -v ${PWD}:/usr/dist zhp-pl:latest
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{env.VERSION}}
+          release_name: Release ${{ env.VERSION }}
+          draft: false
+          prerelease: false
+      - name: Upload Theme
+        id: upload-theme
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: ./zhp-pl.zip
+          asset_name: zhp-pl.zip
+          asset_content_type: application/zip
+      - name: Create details.json
+        run: |
+          echo "{ \"version\": \"$VERSION\", \"details_url\": \"${{ steps.create_release.outputs.html_url }}\",\"download_url\":\"${{ steps.upload-theme.outputs.browser_download_url }}\"  }" > details.json
+
+      - name: Upload release details
+        id: upload-details
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          asset_path: ./details.json
+          asset_name: details.json
+          asset_content_type: application/json

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ yarn-error.log*
 *.njsproj
 *.sln
 *.sw?
+
+package-lock.json
+*.zip

--- a/Dockerfile_build
+++ b/Dockerfile_build
@@ -1,0 +1,48 @@
+FROM node:16.14.2-alpine3.15 as build
+
+ARG THEME_VERSION=latest
+ENV THEME_VERSION=$THEME_VERSION
+
+ARG UPDATE_DETAILS_URL=http://wordpress.przemyslawspaczek.pl/details.json
+ENV UPDATE_DETAILS_URL=$UPDATE_DETAILS_URL
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+
+RUN apk --no-cache add zip
+RUN npm install --quiet
+RUN npm run create-index
+RUN npm run nuxt:build
+
+RUN for i in /usr/src/app/packages/theme/blocks/* ; \
+    do \
+      echo $i; \
+      cd $i  \
+    && npm install --quiet  \
+    && npm run build ; \
+    done
+
+RUN cp -r packages/app/dist/wp-content/themes/zhp-pl/_nuxt packages/theme/ \
+    && rm packages/theme/index.php \
+    && mv packages/app/dist/index.html packages/theme/index.php \
+    && sed -i "s/{VERSION}/${THEME_VERSION}/g" packages/theme/style.css \
+    && UPDATE_DETAILS_URL=$(echo $UPDATE_DETAILS_URL | sed -e 's/\//\\\//g') \
+    && sed -i "s/{UPDATE_DETAILS_URL}/${UPDATE_DETAILS_URL}/g" packages/theme/functions.php
+
+RUN for i in /usr/src/app/packages/theme/blocks/* ; \
+    do \
+      echo $i; \
+      cd $i;  \
+      rm -rf node_modules; \
+    done
+
+RUN cd packages; \
+    mv theme zhp-pl; \
+    zip -r ../zhp-pl.zip zhp-pl/*
+
+FROM alpine:3.15
+
+VOLUME /usr/dist
+COPY --from=build /usr/src/app/zhp-pl.zip zhp-pl.zip
+CMD mv zhp-pl.zip /usr/dist/zhp-pl.zip

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Nowa ZHP
+[![Build theme for WP sites](https://github.com/zhp-wlkp/zhp-pl/actions/workflows/build.yml/badge.svg)](https://github.com/zhp-wlkp/zhp-pl/actions/workflows/build.yml)
+
 **Current status:** Alpha
 
 Project for [The Polish Scouting and Guiding Association (ZHP)](https://zhp.pl/) base on Vue.js UI library, Nuxt.js App and WordPress Integration for content.

--- a/packages/app/pages/_slug.vue
+++ b/packages/app/pages/_slug.vue
@@ -173,7 +173,6 @@
         </ZCarousel>
       </ZSection>
     </template>
-    </component>
   </div>
 </template>
 
@@ -188,8 +187,8 @@ import {
   ZImage,
   ZText
 } from '@zhp-pl/ui'
-import ZWordPress from '@/components/organisms/ZWordPress.vue'
 import { mapGetters } from 'vuex'
+import ZWordPress from '@/components/organisms/ZWordPress.vue'
 
 export default {
   components: {

--- a/packages/theme/blocks/accordion/package-lock.json
+++ b/packages/theme/blocks/accordion/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "accordion",
 			"version": "0.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -2079,7 +2080,6 @@
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.6.2",
@@ -2747,7 +2747,6 @@
 				"jest-resolve": "^26.6.2",
 				"jest-util": "^26.6.2",
 				"jest-worker": "^26.6.2",
-				"node-notifier": "^8.0.0",
 				"slash": "^3.0.0",
 				"source-map": "^0.6.0",
 				"string-length": "^4.0.1",
@@ -2980,7 +2979,6 @@
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.6.2",
@@ -3421,7 +3419,6 @@
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.6.2",
@@ -3770,7 +3767,6 @@
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.6.2",
@@ -9211,7 +9207,6 @@
 			"dependencies": {
 				"anymatch": "~3.1.1",
 				"braces": "~3.0.2",
-				"fsevents": "~2.3.1",
 				"glob-parent": "~5.1.0",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
@@ -11195,8 +11190,7 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"optionator": "^0.8.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -12792,7 +12786,6 @@
 			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
 			"dev": true,
 			"dependencies": {
-				"@types/yauzl": "^2.9.1",
 				"debug": "^4.1.1",
 				"get-stream": "^5.1.0",
 				"yauzl": "^2.10.0"
@@ -13519,7 +13512,6 @@
 			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-2.9.5.tgz",
 			"integrity": "sha512-epSX4Co1YbDv0mjfHouuY0q361TpHE7WQzCp/xMTilxy4kXd+Z23uJzPVorfzbm1a/9q1Yu8T5bndaw65NI4Tg==",
 			"dependencies": {
-				"@emotion/is-prop-valid": "^0.8.2",
 				"framesync": "^4.1.0",
 				"hey-listen": "^1.0.8",
 				"popmotion": "9.0.0-rc.20",
@@ -17669,7 +17661,6 @@
 				"@jest/types": "^24.9.0",
 				"anymatch": "^2.0.0",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.7",
 				"graceful-fs": "^4.1.15",
 				"invariant": "^2.2.4",
 				"jest-serializer": "^24.9.0",
@@ -19069,7 +19060,6 @@
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.6.2",
@@ -19586,7 +19576,6 @@
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.6.2",
@@ -20134,7 +20123,6 @@
 				"@types/node": "*",
 				"anymatch": "^3.0.3",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^2.1.2",
 				"graceful-fs": "^4.2.4",
 				"jest-regex-util": "^26.0.0",
 				"jest-serializer": "^26.6.2",
@@ -20948,9 +20936,6 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
 			"peer": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.6"
-			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -21006,9 +20991,6 @@
 			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
 			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
 			"peer": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.9"
-			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.9"
 			}
@@ -22357,9 +22339,6 @@
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
 			"peer": true,
-			"dependencies": {
-				"graceful-fs": "^4.1.6"
-			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -31113,10 +31092,8 @@
 			"integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
 			"dev": true,
 			"dependencies": {
-				"chokidar": "^3.4.1",
 				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0",
-				"watchpack-chokidar2": "^2.0.1"
+				"neo-async": "^2.5.0"
 			},
 			"optionalDependencies": {
 				"chokidar": "^3.4.1",
@@ -31154,7 +31131,6 @@
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
 				"braces": "^2.3.2",
-				"fsevents": "^1.2.7",
 				"glob-parent": "^3.1.0",
 				"inherits": "^2.0.3",
 				"is-binary-path": "^1.0.0",

--- a/packages/theme/functions.php
+++ b/packages/theme/functions.php
@@ -2,7 +2,7 @@
 // https://github.com/YahnisElsts/plugin-update-checker
 require 'plugin-update-checker-4.11/plugin-update-checker.php';
 $updateChecker = Puc_v4_Factory::buildUpdateChecker(
-    'http://wordpress.przemyslawspaczek.pl/details.json',
+    '{UPDATE_DETAILS_URL}',
     __FILE__,
     'zhp-pl'
 );
@@ -11,8 +11,10 @@ $updateChecker = Puc_v4_Factory::buildUpdateChecker(
 define( 'MY_ACF_PATH', get_stylesheet_directory() . '/includes/acf/' );
 define( 'MY_ACF_URL', get_stylesheet_directory_uri() . '/includes/acf/' );
 
-// Include the ACF plugin.
-include_once( MY_ACF_PATH . 'acf.php' );
+// Require ACF plugin
+if (!class_exists('ACF')) {
+    include_once( MY_ACF_PATH . 'acf.php' );
+}
 
 // Customize the url setting to fix incorrect asset URLs.
 add_filter('acf/settings/url', 'my_acf_settings_url');

--- a/packages/theme/style.css
+++ b/packages/theme/style.css
@@ -2,7 +2,7 @@
 Theme Name: ZHP
 Author: Przemysław Spaczek
 Author URI: https://www.linkedin.com/in/przemyslaw-spaczek/
-Version: 1.3
+Version: {VERSION}
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */


### PR DESCRIPTION
Wordpress theme publishing via Github Releases added.

-  Github releases replace the private template update server. (Maintenance & security improvement.)
-  A workflow that publishes updates has been added.
-  Minor bugfix in _slug.vue.
-  Allow to load ACF plugin through Wordpress plugin manager.

The picture explains how the theme upgrade works.

<img width="1044" alt="163585155-64a435fc-55d5-4e8f-9b50-eac726d5fbf3" src="https://user-images.githubusercontent.com/42292507/164041725-1b386ae1-430c-41b7-b226-e5fcf3726d5e.png">