### PR TITLE
Własne style CSS, kolumny w treści

### DIFF
--- a/packages/app/layouts/default.vue
+++ b/packages/app/layouts/default.vue
@@ -239,6 +239,12 @@ export default {
     }
   },
   mounted () {
+    // Add custom CSS sheet defined in theme configuration
+    const head = document.head || document.getElementsByTagName('head')[0]
+    const style = document.createElement('style')
+    style.innerText = this.$store.getters['theme/customCss']
+    head.appendChild(style)
+
     this.isMobile = matchMedia('(max-width: 640px)').matches
     matchMedia('(max-width: 640px)').addListener((e) => { this.isMobile = e.matches })
     if (localStorage.getItem('cookies')) { return }
@@ -548,5 +554,37 @@ export default {
   z-index: 100;
   bottom: 0;
   left: 0;
+}
+
+.wp-block-columns {
+  flex-wrap: nowrap;
+}
+.is-layout-flex {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+
+  & > * {
+    margin: 0;
+  }
+}
+.wp-block-column {
+  flex-grow: 1;
+  min-width: 0;
+  overflow-wrap: break-word;
+  word-break: break-word;
+
+  @media (max-width: 781px) {
+    .wp-block-columns:not(.is-not-stacked-on-mobile) > & {
+      flex-basis: 100% !important;
+    }
+  }
+
+  @media (min-width: 782px) {
+    .wp-block-columns:not(.is-not-stacked-on-mobile) > & {
+      flex-basis: 0;
+      flex-grow: 1;
+    }
+  }
 }
 </style>

--- a/packages/app/layouts/default.vue
+++ b/packages/app/layouts/default.vue
@@ -240,10 +240,13 @@ export default {
   },
   mounted () {
     // Add custom CSS sheet defined in theme configuration
-    const head = document.head || document.getElementsByTagName('head')[0]
-    const style = document.createElement('style')
-    style.innerText = this.$store.getters['theme/customCss']
-    head.appendChild(style)
+    const customCss = this.$store.getters['theme/customCss']
+    if (customCss) {
+      const head = document.head || document.getElementsByTagName('head')[0]
+      const style = document.createElement('style')
+      style.innerText = customCss
+      head.appendChild(style)
+    }
 
     this.isMobile = matchMedia('(max-width: 640px)').matches
     matchMedia('(max-width: 640px)').addListener((e) => { this.isMobile = e.matches })

--- a/packages/app/store/theme.js
+++ b/packages/app/store/theme.js
@@ -41,5 +41,8 @@ export const getters = {
   },
   colors(state){
     return state.options.colors;
+  },
+  customCss (state) {
+    return state.options.custom_css
   }
 }

--- a/packages/theme/includes/api/options.php
+++ b/packages/theme/includes/api/options.php
@@ -39,6 +39,6 @@ function get_options(WP_REST_Request $request)
         ],
         'header_logos'=>$logos,
         'colors'=>$palette->getValues(),
-        'custom_css' => str_replace(["\r", "\n"], ' ', wp_get_custom_css()),
+        'custom_css' => trim(str_replace(["\r", "\n"], ' ', wp_get_custom_css())),
     );
 }

--- a/packages/theme/includes/api/options.php
+++ b/packages/theme/includes/api/options.php
@@ -38,6 +38,7 @@ function get_options(WP_REST_Request $request)
             '32'=>get_site_icon_url(32)
         ],
         'header_logos'=>$logos,
-        'colors'=>$palette->getValues()
+        'colors'=>$palette->getValues(),
+        'custom_css' => str_replace(["\r", "\n"], ' ', wp_get_custom_css()),
     );
 }


### PR DESCRIPTION
Zmiana dodaje ładowanie własnych styli CSS z konfiguracji motywu (#79) oraz dodaje style do kolumn w treści stron (#80).

Nie robiłem nigdy niczego w Vue - jeśli coś jest niezgodne z konwencją, dajcie proszę znać.