### PR TITLE
Fix news routes ordering

### DIFF
--- a/packages/app/nuxt.config.js
+++ b/packages/app/nuxt.config.js
@@ -51,17 +51,17 @@ export default {
         path: '*',
         component: resolve(__dirname, 'pages/404.vue')
       })
-      
+
       sortRoutes(routes)
 
       routes.unshift({
         name: `news-page`,
-        path: `/:year(\\d+)/:slug`,
+        path: `/:year([1-9][0-9]{3})/:slug`,
         component: resolve(__dirname, 'pages/aktualnosci/_slug.vue')
       })
       routes.unshift({
         name: `news-page-year`,
-        path: `/:year(\\d+)`,
+        path: `/:year([1-9][0-9]{3})`,
         component: resolve(__dirname, 'pages/aktualnosci/_slug.vue')
       })
     }

--- a/packages/app/nuxt.config.js
+++ b/packages/app/nuxt.config.js
@@ -51,20 +51,19 @@ export default {
         path: '*',
         component: resolve(__dirname, 'pages/404.vue')
       })
-      const year = new Date().getFullYear()
-      for (let y = 2010; y <= year; y++) {
-        routes.push({
-          name: `slug-${y}`,
-          path: `/${y}/:slug`,
-          component: resolve(__dirname, 'pages/aktualnosci/_slug.vue')
-        })
-        routes.push({
-          name: `${y}`,
-          path: `/${y}`,
-          component: resolve(__dirname, 'pages/aktualnosci/_slug.vue')
-        })
-      }
+      
       sortRoutes(routes)
+
+      routes.unshift({
+        name: `news-page`,
+        path: `/:year(\\d+)/:slug`,
+        component: resolve(__dirname, 'pages/aktualnosci/_slug.vue')
+      })
+      routes.unshift({
+        name: `news-page-year`,
+        path: `/:year(\\d+)`,
+        component: resolve(__dirname, 'pages/aktualnosci/_slug.vue')
+      })
     }
   },
   ssr: process.env.SSR == 'true',


### PR DESCRIPTION
NuxtJS generuje automatycznie routingi dynamiczne na podstawie nazw katalogów prefixowanych znakiem "_". Aktualności obsługujemy innymi komponentami niż podstrony z tego automatycznego route'a i stąd potrzebne są nowe route'y w extendsRouts. Niestety `sortRoutes(...)` sortuje routy tak, że testowany jest najpierw _slug/_id w przypadku URLi aktualności. 

Oryginalnie autor obszedł to tak, że dodał routy z 1 parametrem i hardcodowanym rokiem. Wówczas funkcja `sortRoutes(...)` umieszcza je ponad _slug/_id z uwagi na mniejszą liczbę parametrów. Hardcodowanie odbywa się na etapie budowania aplikacji, co za tym idzie 1 stycznia powinien iść deploy przebudowujący aplikację. Nie mamy takiego procesu przez co powodujemy awarię na stronach chorągwianych.

 W nowym rozwiązaniu po prostu wstawiam route'y aktualności na początek tablicy.

Dokumentacja: https://nuxtjs.org/docs/get-started/routing/