### PR TITLE
Link z obrazka NIW

### DIFF
--- a/packages/app/pages/index.vue
+++ b/packages/app/pages/index.vue
@@ -246,9 +246,13 @@
             </template>
           </ZCarousel>
         </ZSection>
-        <ZImage
-          :src="`${$config.mediaBaseURL}/wp-content/uploads/2020/11/ROHIS.png`"
-        />
+        <ZLink
+            to="https://niw.gov.pl/"
+        >
+          <ZImage
+            :src="`${$config.mediaBaseURL}/wp-content/uploads/2020/11/ROHIS.png`"
+          />
+        </ZLink>
       </div>
     </ZSection>
   </div>


### PR DESCRIPTION
Zgodnie z wymaganiami NIW, logo ROHIS jest teraz linkiem