### PR TITLE
Zmieniam nazwy funkcji php (fix dla WP 6.4)

### DIFF
--- a/packages/theme/config/colors.php
+++ b/packages/theme/config/colors.php
@@ -1,6 +1,5 @@
 <?php
 
-
 return [
 
     /**

--- a/packages/theme/functions.php
+++ b/packages/theme/functions.php
@@ -1,8 +1,11 @@
 <?php
-
+//region PHP Settings
 ini_set('display_errors', '1');
 ini_set('display_startup_errors', '1');
 error_reporting(E_ALL);
+//endregion
+
+//region Plugin Update Checker
 // https://github.com/YahnisElsts/plugin-update-checker
 require 'plugin-update-checker-4.11/plugin-update-checker.php';
 $updateChecker = Puc_v4_Factory::buildUpdateChecker(
@@ -10,42 +13,66 @@ $updateChecker = Puc_v4_Factory::buildUpdateChecker(
     __FILE__,
     'zhp-pl'
 );
-// ACF
+//endregion
+
+//region Theme support, default filters
+// enable post thumbnails
+add_theme_support('post-thumbnails');
+// remove auto <p>
+remove_filter('the_content', 'wpautop');
+remove_filter('the_excerpt', 'wpautop');
+// disable wp textualizer
+add_filter('run_wptexturize', '__return_false');
+
+function zhppl_remove_core_patterns()
+{
+    remove_theme_support('core-block-patterns');
+}
+
+// remove core patterns
+add_filter('after_setup_theme', 'zhppl_remove_core_patterns');
+//endregion
+
+//region ACF
 // Define path and URL to the ACF plugin.
 function zhppl_dependencies_error_acf()
 {
-    echo '<div class="error"><p>'.__('ZHP-PL, Błąd: Zainstaluj ACF przed włączeniem szablonu.', 'zhp-pl').'</p></div>';
-}
-
-// Require ACF plugin
-if (!class_exists('ACF')) {
-    $acfPath = WP_CONTENT_DIR.'/acf/acf.php';
-    if (file_exists($acfPath)) {
-        define('MY_ACF_PATH', WP_CONTENT_DIR.'/acf/');
-        define('MY_ACF_URL', WP_CONTENT_URL.'/acf/');
-        include_once $acfPath;
-        add_filter('acf/settings/url', 'my_acf_settings_url');
-    } else {
-        add_action('admin_notices', 'zhppl_dependencies_error_acf');
-    }
+    echo '<div class="error"><p>' . __('ZHP-PL, Błąd: Zainstaluj ACF przed włączeniem szablonu.', 'zhp-pl') . '</p></div>';
 }
 
 // Customize the url setting to fix incorrect asset URLs.
-function my_acf_settings_url($url)
+function zhppl_acf_settings_url($url)
 {
     return MY_ACF_URL;
 }
 
 // (Optional) Hide the ACF admin menu item.
-add_filter('acf/settings/show_admin', 'my_acf_settings_show_admin');
-function my_acf_settings_show_admin($show_admin)
+function zhppl_acf_settings_show_admin($show_admin)
 {
     return false;
 }
-if(function_exists('acf_add_local_field_group')):
-    require_once __DIR__.'/includes/acf.php';
-endif;
-// Gutenberg
+
+add_filter('acf/settings/show_admin', 'zhppl_acf_settings_show_admin');
+
+// Require ACF plugin
+if (!class_exists('ACF')) {
+    $acfPath = WP_CONTENT_DIR . '/acf/acf.php';
+    if (file_exists($acfPath)) {
+        define('MY_ACF_PATH', WP_CONTENT_DIR . '/acf/');
+        define('MY_ACF_URL', WP_CONTENT_URL . '/acf/');
+        include_once $acfPath;
+        add_filter('acf/settings/url', 'zhppl_acf_settings_url');
+    } else {
+        add_action('admin_notices', 'zhppl_dependencies_error_acf');
+    }
+}
+
+if (function_exists('acf_add_local_field_group')) {
+    require_once __DIR__ . '/includes/acf.php';
+}
+//endregion
+
+//region Gutenberg
 $blocks = array(
     'accordion',
     'accordion-item',
@@ -56,9 +83,9 @@ $blocks = array(
     'icon'
 );
 foreach ($blocks as $block) {
-    require __DIR__.'/blocks/'.$block.'/'.$block.'.php';
+    require __DIR__ . '/blocks/' . $block . '/' . $block . '.php';
 }
-function zhp_block_category($categories, $context)
+function zhppl_block_category($categories, $context)
 {
     return array_merge(
         $categories,
@@ -70,48 +97,20 @@ function zhp_block_category($categories, $context)
         )
     );
 }
-add_filter('block_categories_all', 'zhp_block_category', 10, 2);
-// remove core patterns
-add_filter('after_setup_theme', 'remove_core_patterns');
-function remove_core_patterns()
+
+add_filter('block_categories_all', 'zhppl_block_category', 10, 2);
+
+function zhppl_allowed_block_types($allowed_blocks, $context)
 {
-    remove_theme_support('core-block-patterns');
-}
-// register new block patterns
-add_action('init', 'register_block_patterns');
-function register_block_patterns()
-{
-//    register_block_pattern_category(
-//        'common',
-//        array( 'label' => 'common' )
-//    );
-//    register_block_pattern(
-//        'my-plugin/my-awesome-pattern',
-//        array(
-//            'title'       => 'title',
-//            'description' => 'description',
-//            'categories'  => array( 'common' ),
-//            'content'     => "",
-//        )
-//    );
+    return $allowed_blocks;
 }
 
 // allowed gutenberg blocks
-add_filter('allowed_block_types_all', 'zhp_allowed_block_types', 10, 2);
-function zhp_allowed_block_types($allowed_blocks, $context)
-{
-    return $allowed_blocks;
-//      return array(
-//          'core/image',
-//          'core/paragraph',
-//          'core/heading',
-//          'core/list'
-//    );
-}
+add_filter('allowed_block_types_all', 'zhppl_allowed_block_types', 10, 2);
+//endregion
 
-// register nav menus
-add_action('init', 'register_menus');
-function register_menus()
+//region Theme capabilities - menus, post statuses
+function zhppl_register_menus()
 {
     register_nav_menus(
         array(
@@ -121,221 +120,30 @@ function register_menus()
         )
     );
 }
-// enable post thumbnails
-add_theme_support('post-thumbnails');
-// remove auto <p>
-remove_filter('the_content', 'wpautop');
-remove_filter('the_excerpt', 'wpautop');
-// disable wp textualizer
-add_filter('run_wptexturize', '__return_false');
 
-function add_random_orderby_to_rest($query_params)
-{
-    $query_params['order']['enum'][] = 'rand';
-    return $query_params;
-}
-add_filter('rest_post_collection_params', 'add_random_orderby_to_rest');
-// register custom post type for logo
-require_once __DIR__.'/includes/posttypes.php';
-// register field to REST for ACF
-add_action('rest_api_init', 'register_rest_acf');
-function register_rest_acf()
-{
-    register_rest_field(
-        array('post', 'page', 'event', 'age_group'),
-        'rest_acf',
-        array(
-            'get_callback' => 'get_rest_acf',
-            'schema' => null
-        )
-    );
-}
-function get_rest_acf($object, $field_name, $request)
-{
-    if (array_key_exists('taxonomy', $object) && $taxonomy = $object['taxonomy']) {
-        $acf = get_fields($taxonomy.'_'.$object['id']);
-    } else {
-        $acf = get_fields($object['id']);
-    }
-    return $acf;
-}
-// register field to REST for age_group
-add_action('rest_api_init', 'register_rest_age_group');
-function register_rest_age_group()
-{
-    register_rest_field(
-        array('event'),
-        'rest_age_group',
-        array(
-            'get_callback' => 'get_rest_age_group',
-            'schema' => null
-        )
-    );
-}
-function get_rest_age_group($object, $field_name, $request)
-{
-    $term_taxonomy_id = $object['age_groups'][0];
-    $age_group = get_term_by('term_taxonomy_id', $term_taxonomy_id);
-    $acf = get_fields('age_group_'.$term_taxonomy_id);
-    return (object) array_merge((array) $age_group, (array) $acf);
-}
-// register field to REST for event_type
-add_action('rest_api_init', 'register_rest_event_type');
-function register_rest_event_type()
-{
-    register_rest_field(
-        array('event'),
-        'rest_event_type',
-        array(
-            'get_callback' => 'get_rest_event_type',
-            'schema' => null
-        )
-    );
-}
-function get_rest_event_type($object, $field_name, $request)
-{
-    $term_taxonomy_id = $object['event_types'][0];
-    $event_type = get_term_by('term_taxonomy_id', $term_taxonomy_id);
-    return $event_type;
-}
-// register field to REST for media
-add_action('rest_api_init', 'register_rest_media');
-function register_rest_media()
-{
-    register_rest_field(
-        array('post', 'event', 'logo'),
-        'rest_media',
-        array(
-            'get_callback' => 'get_rest_media',
-            'schema' => null
-        )
-    );
-};
-function get_rest_media($object, $field_name, $request)
-{
-    if (!array_key_exists('featured_media', $object) || !$object['featured_media']) {
-        return false;
-    }
-    $media = wp_get_attachment_image_src($object['featured_media'], 'large')[0];
-    return $media;
-};
-// register field to REST for author
-add_action('rest_api_init', 'register_rest_author');
-function register_rest_author()
-{
-    register_rest_field(
-        array('post', 'event'),
-        'rest_author',
-        array(
-            'get_callback' => 'get_rest_author',
-            'schema' => null
-        )
-    );
-};
-function get_rest_author($object, $field_name, $request)
-{
-    if (!array_key_exists('author', $object) || !$object['author']) {
-        return false;
-    }
-    $author = (object) array(
-        'name' => get_the_author_meta('display_name', $object['author']),
-        'href'=> get_author_posts_url($object['author']),
-        'avatar_url' => get_avatar_url($object['author'], (object) array('size' => '48'))
-    );
-    return $author;
-};
-// register field to REST for gutenberg
-add_action('rest_api_init', 'register_rest_gutenberg');
-function register_rest_gutenberg()
-{
-    register_rest_field(
-        array('post', 'page'),
-        'rest_gutenberg',
-        array(
-            'get_callback' => 'get_rest_gutenberg',
-            'schema' => null
-        )
-    );
-};
-function get_rest_gutenberg($object, $field_name, $request, $object_type)
-{
-    if (!array_key_exists('content', $object) || !$object['content']) {
-        return false;
-    }
-    return parse_blocks(get_the_content(null, false, $object['id']));
-};
-// register field to REST for reading_time
-add_action('rest_api_init', 'register_rest_reading_time');
-function register_rest_reading_time()
-{
-    register_rest_field(
-        array('post'),
-        'rest_reading_time',
-        array(
-            'get_callback' => 'get_rest_reading_time',
-            'schema' => null
-        )
-    );
-};
-function get_rest_reading_time($object, $field_name, $request, $object_type)
-{
-    if (!array_key_exists('content', $object) || !$object['content']) {
-        return false;
-    }
-    $word_count = str_word_count(strip_tags($object['content']['rendered']));
-    return ceil($word_count / 200);
-};
-// register field to REST for reading_time
-add_action('rest_api_init', 'register_rest_redirect');
-function register_rest_redirect()
-{
-    register_rest_field(
-        array('post', 'page'),
-        'rest_redirect',
-        array(
-            'get_callback' => 'get_rest_redirect',
-            'schema' => null
-        )
-    );
-};
-function get_rest_redirect($object, $field_name, $request, $object_type)
-{
-    if (!array_key_exists('content', $object) || !$object['content']) {
-        return false;
-    }
-    return get_post_meta($object['id'], '_pprredirect_url', true);
-};
-
-function custom_parent_dropdown_limit($args, $request)
-{
-    if (is_user_logged_in()) {
-        $args['posts_per_page'] = 1000;
-    }
-    return $args;
-}
-add_filter('rest_page_query', 'custom_parent_dropdown_limit', 20, 2);
-
-require_once 'includes/autoload.php';
-// register endpoint to REST for events
+// register nav menus
+add_action('init', 'zhppl_register_menus');
 
 // new post status
-function temporary_post_status()
+function zhppl_temporary_post_status()
 {
     $args = array(
-        'label'                     => _x('Tymczasowy', 'Status General Name', 'text_domain'),
-        'label_count'               => _n_noop('Tymczasowy (%s)', 'Tymczasowe (%s)', 'text_domain'),
-        'public'                    => false,
+        'label' => _x('Tymczasowy', 'Status General Name', 'text_domain'),
+        'label_count' => _n_noop('Tymczasowy (%s)', 'Tymczasowe (%s)', 'text_domain'),
+        'public' => false,
     );
     register_post_status('temporary', $args);
 }
-add_action('init', 'temporary_post_status', 0);
+
+add_action('init', 'zhppl_temporary_post_status', 0);
+
 // notification after transition event status from temporaty to pending
-function transition_post_to_pending($new_status, $old_status, $post)
+function zhppl_transition_post_to_pending($new_status, $old_status, $post)
 {
-    if(!get_theme_mod('email', '')) {
+    if (!get_theme_mod('email', '')) {
         return;
     }
-    if(('pending' === $new_status && 'temporary' === $old_status) && 'event' === $post->post_type) {
+    if (('pending' === $new_status && 'temporary' === $old_status) && 'event' === $post->post_type) {
         $to = get_theme_mod('email', '');
         $subject = get_theme_mod('title', '');
         $site_url = site_url();
@@ -345,4 +153,223 @@ function transition_post_to_pending($new_status, $old_status, $post)
         wp_mail($to, $subject, $message, $headers);
     }
 }
-add_action('transition_post_status', 'transition_post_to_pending', 10, 3);
+
+add_action('transition_post_status', 'zhppl_transition_post_to_pending', 10, 3);
+//endregion
+
+//region ACF Rest Endpoints
+function zhppl_add_random_orderby_to_rest($query_params)
+{
+    $query_params['order']['enum'][] = 'rand';
+    return $query_params;
+}
+
+add_filter('rest_post_collection_params', 'zhppl_add_random_orderby_to_rest');
+
+// register custom post type for logo
+require_once __DIR__ . '/includes/posttypes.php';
+
+function zhppl_get_rest_acf($object, $field_name, $request)
+{
+    if (array_key_exists('taxonomy', $object) && $taxonomy = $object['taxonomy']) {
+        $acf = get_fields($taxonomy . '_' . $object['id']);
+    } else {
+        $acf = get_fields($object['id']);
+    }
+    return $acf;
+}
+
+function zhppl_register_rest_acf()
+{
+    register_rest_field(
+        array('post', 'page', 'event', 'age_group'),
+        'rest_acf',
+        array(
+            'get_callback' => 'zhppl_get_rest_acf',
+            'schema' => null
+        )
+    );
+}
+
+// register field to REST for ACF
+add_action('rest_api_init', 'zhppl_register_rest_acf');
+
+function zhppl_get_rest_age_group($object, $field_name, $request)
+{
+    $term_taxonomy_id = $object['age_groups'][0];
+    $age_group = get_term_by('term_taxonomy_id', $term_taxonomy_id);
+    $acf = get_fields('age_group_' . $term_taxonomy_id);
+    return (object)array_merge((array)$age_group, (array)$acf);
+}
+
+function zhppl_register_rest_age_group()
+{
+    register_rest_field(
+        array('event'),
+        'rest_age_group',
+        array(
+            'get_callback' => 'zhppl_get_rest_age_group',
+            'schema' => null
+        )
+    );
+}
+
+// register field to REST for age_group
+add_action('rest_api_init', 'zhppl_register_rest_age_group');
+
+function zhppl_get_rest_event_type($object, $field_name, $request)
+{
+    $term_taxonomy_id = $object['event_types'][0];
+    $event_type = get_term_by('term_taxonomy_id', $term_taxonomy_id);
+    return $event_type;
+}
+
+function zhppl_register_rest_event_type()
+{
+    register_rest_field(
+        array('event'),
+        'rest_event_type',
+        array(
+            'get_callback' => 'zhppl_get_rest_event_type',
+            'schema' => null
+        )
+    );
+}
+
+// register field to REST for event_type
+add_action('rest_api_init', 'zhppl_register_rest_event_type');
+
+function zhppl_get_rest_media($object, $field_name, $request)
+{
+    if (!array_key_exists('featured_media', $object) || !$object['featured_media']) {
+        return false;
+    }
+    $media = wp_get_attachment_image_src($object['featured_media'], 'large')[0];
+    return $media;
+}
+
+function zhppl_register_rest_media()
+{
+    register_rest_field(
+        array('post', 'event', 'logo'),
+        'rest_media',
+        array(
+            'get_callback' => 'zhppl_get_rest_media',
+            'schema' => null
+        )
+    );
+}
+
+// register field to REST for media
+add_action('rest_api_init', 'zhppl_register_rest_media');
+
+function zhppl_get_rest_author($object, $field_name, $request)
+{
+    if (!array_key_exists('author', $object) || !$object['author']) {
+        return false;
+    }
+    $author = (object)array(
+        'name' => get_the_author_meta('display_name', $object['author']),
+        'href' => get_author_posts_url($object['author']),
+        'avatar_url' => get_avatar_url($object['author'], (object)array('size' => '48'))
+    );
+    return $author;
+}
+
+function zhppl_register_rest_author()
+{
+    register_rest_field(
+        array('post', 'event'),
+        'rest_author',
+        array(
+            'get_callback' => 'zhppl_get_rest_author',
+            'schema' => null
+        )
+    );
+}
+
+// register field to REST for author
+add_action('rest_api_init', 'zhppl_register_rest_author');
+
+function zhppl_get_rest_gutenberg($object, $field_name, $request, $object_type)
+{
+    if (!array_key_exists('content', $object) || !$object['content']) {
+        return false;
+    }
+    return parse_blocks(get_the_content(null, false, $object['id']));
+}
+
+function zhppl_register_rest_gutenberg()
+{
+    register_rest_field(
+        array('post', 'page'),
+        'rest_gutenberg',
+        array(
+            'get_callback' => 'zhppl_get_rest_gutenberg',
+            'schema' => null
+        )
+    );
+}
+
+// register field to REST for gutenberg
+add_action('rest_api_init', 'zhppl_register_rest_gutenberg');
+
+function zhppl_get_rest_reading_time($object, $field_name, $request, $object_type)
+{
+    if (!array_key_exists('content', $object) || !$object['content']) {
+        return false;
+    }
+    $word_count = str_word_count(strip_tags($object['content']['rendered']));
+    return ceil($word_count / 200);
+}
+
+function zhppl_register_rest_reading_time()
+{
+    register_rest_field(
+        array('post'),
+        'rest_reading_time',
+        array(
+            'get_callback' => 'zhppl_get_rest_reading_time',
+            'schema' => null
+        )
+    );
+}
+
+// register field to REST for reading_time
+add_action('rest_api_init', 'zhppl_register_rest_reading_time');
+
+function zhppl_get_rest_redirect($object, $field_name, $request, $object_type)
+{
+    if (!array_key_exists('content', $object) || !$object['content']) {
+        return false;
+    }
+    return get_post_meta($object['id'], '_pprredirect_url', true);
+}
+
+function zhppl_register_rest_redirect()
+{
+    register_rest_field(
+        array('post', 'page'),
+        'rest_redirect',
+        array(
+            'get_callback' => 'zhppl_get_rest_redirect',
+            'schema' => null
+        )
+    );
+}
+
+// register field to REST for reading_time
+add_action('rest_api_init', 'zhppl_register_rest_redirect');
+
+function zhppl_custom_parent_dropdown_limit($args, $request)
+{
+    if (is_user_logged_in()) {
+        $args['posts_per_page'] = 1000;
+    }
+    return $args;
+}
+
+add_filter('rest_page_query', 'zhppl_custom_parent_dropdown_limit', 20, 2);
+//endregion
+
+require_once 'includes/autoload.php';

--- a/packages/theme/includes/acf.php
+++ b/packages/theme/includes/acf.php
@@ -1,6 +1,4 @@
 <?php
-
-
 acf_add_local_field_group(array(
     'key' => 'group_6057099b2162c',
     'title' => 'Strona główna',

--- a/packages/theme/includes/api/acf-events.php
+++ b/packages/theme/includes/api/acf-events.php
@@ -1,15 +1,6 @@
 <?php
 
-add_action('rest_api_init', 'register_rest_events');
-function register_rest_events()
-{
-    register_rest_route('wp/v2', '/acf-events', array(
-        'methods' => 'GET',
-        'callback' => 'get_acf_events',
-        'permission_callback'=>'__return_true'
-    ));
-}
-function get_acf_events(WP_REST_Request $request)
+function zhppl_get_acf_events(WP_REST_Request $request)
 {
     // request params
     list(
@@ -22,7 +13,7 @@ function get_acf_events(WP_REST_Request $request)
         'localizations' => $localizations,
         'without_outdated' => $without_outdated,
         'event_categories' => $event_categories,
-    ) = $request;
+        ) = $request;
 
     // meta_query -> date from ACF
     $meta_query = array(
@@ -154,3 +145,14 @@ function get_acf_events(WP_REST_Request $request)
 
     return $response;
 }
+
+function zhppl_register_rest_events()
+{
+    register_rest_route('wp/v2', '/acf-events', array(
+        'methods' => 'GET',
+        'callback' => 'zhppl_get_acf_events',
+        'permission_callback'=>'__return_true'
+    ));
+}
+
+add_action('rest_api_init', 'zhppl_register_rest_events');

--- a/packages/theme/includes/api/instagram.php
+++ b/packages/theme/includes/api/instagram.php
@@ -1,18 +1,18 @@
 <?php
-
-
-// register endpoint to REST for instagram
-add_action('rest_api_init', 'register_rest_instagram');
-function register_rest_instagram()
-{
-    register_rest_route('wp/v2', '/instagram', array(
-        'methods' => 'GET',
-        'callback' => 'get_instagram',
-        'permission_callback'=>'__return_true'
-    ));
-}
-function get_instagram(WP_REST_Request $request)
+function zhppl_get_instagram(WP_REST_Request $request)
 {
     $instagram = do_shortcode('[instagram-feed]');
     return $instagram;
 }
+
+function zhppl_register_rest_instagram()
+{
+    register_rest_route('wp/v2', '/instagram', array(
+        'methods' => 'GET',
+        'callback' => 'zhppl_get_instagram',
+        'permission_callback'=>'__return_true'
+    ));
+}
+
+// register endpoint to REST for instagram
+add_action('rest_api_init', 'zhppl_register_rest_instagram');

--- a/packages/theme/includes/api/menus.php
+++ b/packages/theme/includes/api/menus.php
@@ -1,16 +1,5 @@
 <?php
-
-// register endpoint to REST for menu
-add_action('rest_api_init', 'register_rest_menus');
-function register_rest_menus()
-{
-    register_rest_route('wp/v2', '/menus', array(
-        'methods' => 'GET',
-        'callback' => 'get_menus',
-        'permission_callback'=>'__return_true'
-    ));
-}
-function get_menus(WP_REST_Request $request)
+function zhppl_get_menus(WP_REST_Request $request)
 {
     $nav_menus = array();
     $registered_nav_menus = get_nav_menu_locations();
@@ -25,3 +14,15 @@ function get_menus(WP_REST_Request $request)
     }
     return $nav_menus;
 }
+
+function zhppl_register_rest_menus()
+{
+    register_rest_route('wp/v2', '/menus', array(
+        'methods' => 'GET',
+        'callback' => 'zhppl_get_menus',
+        'permission_callback'=>'__return_true'
+    ));
+}
+
+// register endpoint to REST for menu
+add_action('rest_api_init', 'zhppl_register_rest_menus');

--- a/packages/theme/includes/api/options.php
+++ b/packages/theme/includes/api/options.php
@@ -1,15 +1,5 @@
 <?php
-
-add_action('rest_api_init', 'register_rest_options');
-function register_rest_options()
-{
-    register_rest_route('wp/v2', '/options', array(
-        'methods' => 'GET',
-        'callback' => 'get_options',
-        'permission_callback'=>'__return_true'
-    ));
-}
-function get_options(WP_REST_Request $request)
+function zhppl_get_options(WP_REST_Request $request)
 {
     $config = require_once __DIR__.'/../../config/colors.php';
     $palette = new Palette();
@@ -42,3 +32,14 @@ function get_options(WP_REST_Request $request)
         'custom_css' => trim(str_replace(["\r", "\n"], ' ', wp_get_custom_css())),
     );
 }
+
+function zhppl_register_rest_options()
+{
+    register_rest_route('wp/v2', '/options', array(
+        'methods' => 'GET',
+        'callback' => 'zhppl_get_options',
+        'permission_callback'=>'__return_true'
+    ));
+}
+
+add_action('rest_api_init', 'zhppl_register_rest_options');

--- a/packages/theme/includes/api/post-events.php
+++ b/packages/theme/includes/api/post-events.php
@@ -1,17 +1,5 @@
 <?php
-
-
-// none logged users can add new event
-add_action('rest_api_init', 'register_rest_post_events');
-function register_rest_post_events()
-{
-    register_rest_route('wp/v2', '/post-events', array(
-        'methods' => 'POST',
-        'callback' => 'post_events',
-        'permission_callback'=>'__return_true'
-    ));
-}
-function post_events(WP_REST_Request $request)
+function zhppl_post_events(WP_REST_Request $request)
 {
     // $headers['origin'][0] === 'http://localhost:3000'
     $file = $request->get_file_params();
@@ -35,7 +23,7 @@ function post_events(WP_REST_Request $request)
         'to_confirm' => $to_confirm,
         'id' => $id,
         'token' => $key
-    ) = $request;
+        ) = $request;
 
     if($id && $key) {
         $status = get_post_status($id);
@@ -160,3 +148,15 @@ function post_events(WP_REST_Request $request)
         'message' => 'Sprawdź swojego maila i kliknij w link aby potwierdzić swoje wydarzenie.'
     );
 }
+
+function zhppl_register_rest_post_events()
+{
+    register_rest_route('wp/v2', '/post-events', array(
+        'methods' => 'POST',
+        'callback' => 'zhppl_post_events',
+        'permission_callback'=>'__return_true'
+    ));
+}
+
+// none logged users can add new event
+add_action('rest_api_init', 'zhppl_register_rest_post_events');

--- a/packages/theme/includes/api/random.php
+++ b/packages/theme/includes/api/random.php
@@ -1,16 +1,5 @@
 <?php
-
-// register endpoint to REST for random
-add_action('rest_api_init', 'register_rest_random');
-function register_rest_random()
-{
-    register_rest_route('wp/v2', '/random', array(
-        'methods' => 'GET',
-        'callback' => 'get_random',
-        'permission_callback'=>'__return_true'
-    ));
-}
-function get_random(WP_REST_Request $request)
+function zhppl_get_random(WP_REST_Request $request)
 {
     $args = array(
         'post_status' => 'publish',
@@ -26,3 +15,15 @@ function get_random(WP_REST_Request $request)
     wp_reset_postdata();
     return $posts;
 }
+
+function zhppl_register_rest_random()
+{
+    register_rest_route('wp/v2', '/random', array(
+        'methods' => 'GET',
+        'callback' => 'zhppl_get_random',
+        'permission_callback'=>'__return_true'
+    ));
+}
+
+// register endpoint to REST for random
+add_action('rest_api_init', 'zhppl_register_rest_random');

--- a/packages/theme/includes/colors/Color.php
+++ b/packages/theme/includes/colors/Color.php
@@ -1,5 +1,4 @@
 <?php
-
 class Color
 {
     /**

--- a/packages/theme/includes/posttypes.php
+++ b/packages/theme/includes/posttypes.php
@@ -1,7 +1,5 @@
 <?php
-
-add_action('init', 'add_random_to_post_type', 0);
-function add_random_to_post_type()
+function zhppl_add_random_to_post_type()
 {
     $labels = array(
         'name'                  => _x('Losowy tekst', 'Post Type General Name', 'text_domain'),
@@ -40,8 +38,9 @@ function add_random_to_post_type()
     register_post_type('random', $args);
 }
 
-add_action('init', 'add_logo_to_post_type', 0);
-function add_logo_to_post_type()
+add_action('init', 'zhppl_add_random_to_post_type', 0);
+
+function zhppl_add_logo_to_post_type()
 {
     $labels = array(
         'name'                  => _x('Logotyp', 'Post Type General Name', 'text_domain'),
@@ -79,9 +78,11 @@ function add_logo_to_post_type()
     );
     register_post_type('logo', $args);
 }
+
+add_action('init', 'zhppl_add_logo_to_post_type', 0);
+
 // register custom post type for event
-add_action('init', 'add_event_to_post_type', 0);
-function add_event_to_post_type()
+function zhppl_add_event_to_post_type()
 {
     $labels = array(
         'name'                  => _x('Wydarzenia', 'Post Type General Name', 'text_domain'),
@@ -120,40 +121,10 @@ function add_event_to_post_type()
     register_post_type('event', $args);
 }
 
-// register custom taxonomy for teams
-// add_action( 'init', 'add_teams_to_taxonomy', 0 );
-function add_teams_to_taxonomy()
-{
-    $labels = array(
-        'name'                       => _x('Zespoły', 'Taxonomy General Name', 'text_domain'),
-        'singular_name'              => _x('Zespół', 'Taxonomy Singular Name', 'text_domain'),
-        'menu_name'                  => __('Zespoły', 'text_domain'),
-        'all_items'                  => __('Zespoły', 'text_domain'),
-    );
-    $rewrite = array(
-        'slug'                       => 'team',
-        'with_front'                 => true,
-        'hierarchical'               => false,
-    );
-    $args = array(
-        'labels'                     => $labels,
-        'hierarchical'               => true,
-        'public'                     => true,
-        'show_ui'                    => true,
-        'show_admin_column'          => true,
-        'show_in_nav_menus'          => true,
-        'show_tagcloud'              => true,
-        'query_var'                  => 'team',
-        'rewrite'                    => $rewrite,
-        'show_in_rest'               => true,
-        'rest_base'                  => 'teams',
-        'rest_controller_class'      => 'WP_REST_Terms_Controller',
-    );
-    register_taxonomy('team', array( 'post' ), $args);
-}
+add_action('init', 'zhppl_add_event_to_post_type', 0);
+
 // register custom taxonomy for districts
-add_action('init', 'add_localization_to_taxonomy', 0);
-function add_localization_to_taxonomy()
+function zhppl_add_localization_to_taxonomy()
 {
     $labels = array(
         'name'                       => _x('Lokalizacja', 'Taxonomy General Name', 'text_domain'),
@@ -182,40 +153,11 @@ function add_localization_to_taxonomy()
     );
     register_taxonomy('localization', array( 'event' ), $args);
 }
-// register custom taxonomy for unit
-// add_action( 'init', 'add_unit_to_taxonomy', 0 );
-function add_unit_to_taxonomy()
-{
-    $labels = array(
-        'name'                       => _x('Jednostki', 'Taxonomy General Name', 'text_domain'),
-        'singular_name'              => _x('Jednostka', 'Taxonomy Singular Name', 'text_domain'),
-        'menu_name'                  => __('Jednostki', 'text_domain'),
-        'all_items'                  => __('Jednostki', 'text_domain'),
-    );
-    $rewrite = array(
-        'slug'                       => 'unit',
-        'with_front'                 => true,
-        'hierarchical'               => false,
-    );
-    $args = array(
-        'labels'                     => $labels,
-        'hierarchical'               => true,
-        'public'                     => true,
-        'show_ui'                    => true,
-        'show_admin_column'          => true,
-        'show_in_nav_menus'          => true,
-        'show_tagcloud'              => true,
-        'query_var'                  => 'unit',
-        'rewrite'                    => $rewrite,
-        'show_in_rest'               => true,
-        'rest_base'                  => 'units',
-        'rest_controller_class'      => 'WP_REST_Terms_Controller',
-    );
-    register_taxonomy('units', array( 'post', 'event', 'logo' ), $args);
-}
+
+add_action('init', 'zhppl_add_localization_to_taxonomy', 0);
+
 // register custom taxonomy for random_category
-add_action('init', 'add_event_category_to_taxonomy', 0);
-function add_event_category_to_taxonomy()
+function zhppl_add_event_category_to_taxonomy()
 {
     $labels = array(
         'name'                       => _x('Kategorie', 'Taxonomy General Name', 'text_domain'),
@@ -244,9 +186,11 @@ function add_event_category_to_taxonomy()
     );
     register_taxonomy('event_category', array( 'event' ), $args);
 }
+
+add_action('init', 'zhppl_add_event_category_to_taxonomy', 0);
+
 // register custom taxonomy for event_type
-add_action('init', 'add_event_type_to_taxonomy', 0);
-function add_event_type_to_taxonomy()
+function zhppl_add_event_type_to_taxonomy()
 {
     $labels = array(
         'name'                       => _x('Rodzaje wydarzenia', 'Taxonomy General Name', 'text_domain'),
@@ -275,9 +219,11 @@ function add_event_type_to_taxonomy()
     );
     register_taxonomy('event_type', array( 'event' ), $args);
 }
+
+add_action('init', 'zhppl_add_event_type_to_taxonomy', 0);
+
 // register custom taxonomy for age_group
-add_action('init', 'add_age_group_to_taxonomy', 0);
-function add_age_group_to_taxonomy()
+function zhppl_add_age_group_to_taxonomy()
 {
     $labels = array(
         'name'                       => _x('Metodyki', 'Taxonomy General Name', 'text_domain'),
@@ -306,9 +252,11 @@ function add_age_group_to_taxonomy()
     );
     register_taxonomy('age_group', array( 'event' ), $args);
 }
+
+add_action('init', 'zhppl_add_age_group_to_taxonomy', 0);
+
 // register custom taxonomy for random_category
-add_action('init', 'add_random_category_to_taxonomy', 0);
-function add_random_category_to_taxonomy()
+function zhppl_add_random_category_to_taxonomy()
 {
     $labels = array(
         'name'                       => _x('Kategorie', 'Taxonomy General Name', 'text_domain'),
@@ -337,9 +285,11 @@ function add_random_category_to_taxonomy()
     );
     register_taxonomy('random_category', array( 'random' ), $args);
 }
+
+add_action('init', 'zhppl_add_random_category_to_taxonomy', 0);
+
 // register custom taxonomy for logo_category
-add_action('init', 'add_logo_category_to_taxonomy', 0);
-function add_logo_category_to_taxonomy()
+function zhppl_add_logo_category_to_taxonomy()
 {
     $labels = array(
         'name'                       => _x('Kategorie', 'Taxonomy General Name', 'text_domain'),
@@ -368,3 +318,5 @@ function add_logo_category_to_taxonomy()
     );
     register_taxonomy('logo_category', array( 'logo' ), $args);
 }
+
+add_action('init', 'zhppl_add_logo_category_to_taxonomy', 0);

--- a/packages/theme/includes/settings.php
+++ b/packages/theme/includes/settings.php
@@ -1,12 +1,9 @@
 <?php
-
-add_action('customize_register', 'theme_customize_register');
-function theme_customize_register($wp_customize)
+function zhppl_theme_customize_register($wp_customize)
 {
     $config = require_once __DIR__.'/../config/colors.php';
     $palette = new Palette();
     $palette->load($config);
-
 
     $wp_customize->add_panel('theme', array(
         'title'=> 'Ustawienia motywu',
@@ -131,7 +128,7 @@ function theme_customize_register($wp_customize)
         'priority'=>10,
         'section'=>'event',
         'label'=>'Dozwolone domeny',
-        'description'=>'Wprowadź domeny adresów e-mail, z których można zgłaszać wydarzenia (rozdzielone przecinkiem).'
+        'description'=>'Wprowadź domeny adresów e-mail, z których można zgłaszać wydarzenia (rozdzielone przecinkiem). UWAGA: domeny tutaj wypływają także na interpretację linków w menu. Jeśli linki w menu zachowują się dziwnie, nie zapomnij dodać tu domeny tej strony! Więcej informacji znajduje się w notce instrukcji motywu.'
     ));
     $wp_customize->add_setting('subject', array(
         'type' => 'theme_mod',
@@ -178,3 +175,5 @@ function theme_customize_register($wp_customize)
         'description'=>'Wprowadź tytuł maila który zostanie wysłany z powiadomieniem.'
     ));
 }
+
+add_action('customize_register', 'zhppl_theme_customize_register');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4373f8218940aa47f06dd340708e3596b6c96add2454432fd28cc4823f1072af
-size 731696
+oid sha256:5bd71d88935a2dfdae34f56a39c9616f859bf3ab2ae44055e52b5933e7a4affc
+size 758947


### PR DESCRIPTION
## Zmienione
- Wszystkim motywowym funkcjom php dodałem prefix `zhppl_`, żeby wyróżnić je od innych funkcji wordpressowych/pluginowych. **Naprawia to** błąd występujący po aktualizacji WordPressa do 6.4 z redeklaracją funkcji `wp_options`
- Zmieniłem opis w ekranie dostosowywania motywu, żeby uwzględniał informajcę o tym, że dodanie nazwy domeny w ustawieniach może naprawić błąd z źle funkcjonującymi linkami w menu
- Zmieniłem nieco organizację kodu w `functions.php`; pozamieniałem kolejnością funkcje i wywołania `add_action` (żeby w logicznym ciągu najpierw była deklaracja, potem egzekucja); pogrupowałem funkcje po ich kategorii i dodałem regiony kodu (obsługiwane na pewno przez jetbrainsowe edytory).

## Usunięte
- W wyniku cleanupu wywaliłem kilka funkcji, które nie były używane (wykomentowane)