### PR TITLE
Add prefixes to REST route registration callbacks (theme)

### DIFF
--- a/packages/theme/functions.php
+++ b/packages/theme/functions.php
@@ -1,8 +1,5 @@
 <?php
 
-ini_set('display_errors', '1');
-ini_set('display_startup_errors', '1');
-error_reporting(E_ALL);
 // https://github.com/YahnisElsts/plugin-update-checker
 require 'plugin-update-checker-4.11/plugin-update-checker.php';
 $updateChecker = Puc_v4_Factory::buildUpdateChecker(

--- a/packages/theme/includes/api/acf-events.php
+++ b/packages/theme/includes/api/acf-events.php
@@ -5,11 +5,11 @@ function register_rest_events()
 {
     register_rest_route('wp/v2', '/acf-events', array(
         'methods' => 'GET',
-        'callback' => 'get_acf_events',
+        'callback' => 'zhp_route_get_acf_events',
         'permission_callback'=>'__return_true'
     ));
 }
-function get_acf_events(WP_REST_Request $request)
+function zhp_route_get_acf_events(WP_REST_Request $request)
 {
     // request params
     list(

--- a/packages/theme/includes/api/instagram.php
+++ b/packages/theme/includes/api/instagram.php
@@ -7,11 +7,11 @@ function register_rest_instagram()
 {
     register_rest_route('wp/v2', '/instagram', array(
         'methods' => 'GET',
-        'callback' => 'get_instagram',
+        'callback' => 'zhp_route_get_instagram',
         'permission_callback'=>'__return_true'
     ));
 }
-function get_instagram(WP_REST_Request $request)
+function zhp_route_get_instagram(WP_REST_Request $request)
 {
     $instagram = do_shortcode('[instagram-feed]');
     return $instagram;

--- a/packages/theme/includes/api/menus.php
+++ b/packages/theme/includes/api/menus.php
@@ -6,11 +6,11 @@ function register_rest_menus()
 {
     register_rest_route('wp/v2', '/menus', array(
         'methods' => 'GET',
-        'callback' => 'get_menus',
+        'callback' => 'zhp_route_get_menus',
         'permission_callback'=>'__return_true'
     ));
 }
-function get_menus(WP_REST_Request $request)
+function zhp_route_get_menus(WP_REST_Request $request)
 {
     $nav_menus = array();
     $registered_nav_menus = get_nav_menu_locations();

--- a/packages/theme/includes/api/options.php
+++ b/packages/theme/includes/api/options.php
@@ -5,11 +5,11 @@ function register_rest_options()
 {
     register_rest_route('wp/v2', '/options', array(
         'methods' => 'GET',
-        'callback' => 'get_options',
+        'callback' => 'zhp_route_get_options',
         'permission_callback'=>'__return_true'
     ));
 }
-function get_options(WP_REST_Request $request)
+function zhp_route_get_options(WP_REST_Request $request)
 {
     $config = require_once __DIR__.'/../../config/colors.php';
     $palette = new Palette();

--- a/packages/theme/includes/api/post-events.php
+++ b/packages/theme/includes/api/post-events.php
@@ -7,11 +7,11 @@ function register_rest_post_events()
 {
     register_rest_route('wp/v2', '/post-events', array(
         'methods' => 'POST',
-        'callback' => 'post_events',
+        'callback' => 'zhp_route_post_events',
         'permission_callback'=>'__return_true'
     ));
 }
-function post_events(WP_REST_Request $request)
+function zhp_route_post_events(WP_REST_Request $request)
 {
     // $headers['origin'][0] === 'http://localhost:3000'
     $file = $request->get_file_params();

--- a/packages/theme/includes/api/random.php
+++ b/packages/theme/includes/api/random.php
@@ -6,11 +6,11 @@ function register_rest_random()
 {
     register_rest_route('wp/v2', '/random', array(
         'methods' => 'GET',
-        'callback' => 'get_random',
+        'callback' => 'zhp_route_get_random',
         'permission_callback'=>'__return_true'
     ));
 }
-function get_random(WP_REST_Request $request)
+function zhp_route_get_random(WP_REST_Request $request)
 {
     $args = array(
         'post_status' => 'publish',


### PR DESCRIPTION
One of functions in use without any prefix which would be specific for the theme (IMHO that's against good patterns in obsolete coding in PHP = when there are no namespaces) started to be a duplicate of get_options WP function introduced since version 6.4.0 (hmmm... who could suspect that this "original" function name could become in use by WP or any other theme/plugin? :P).
Moreover this pull request removes hardcoded error reporting settings which should be declared for development environments only on CMS level instead of in a code of a theme (so that's another bad pattern in use here).